### PR TITLE
Build `intellij-idea-community` and `pycharm-community` from sources

### DIFF
--- a/intellij-idea-community-bin/intellij-idea-community-bin.spec
+++ b/intellij-idea-community-bin/intellij-idea-community-bin.spec
@@ -25,12 +25,13 @@
 
 Name:    %{_name}-bin
 Version: 2024.1.4
-Release: 2%{?dist}
+Release: 1%{?dist}
 Summary: Capable and Ergonomic Java IDE - Community Edition
 License: Apache-2.0
 URL:     https://www.jetbrains.com/%{appname}/
 
 Provides: %{_name}
+
 Source0: %{_name}.desktop
 
 BuildRequires: desktop-file-utils
@@ -137,52 +138,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{_name}.desktop
 
 %changelog
 * Fri Jun 21 2024 M3DZIK <me@medzik.dev> - 2024.1.4-1
-- Update to 2024.1.4 (241.18034.62)
-
-* Mon Jun 10 2024 M3DZIK <me@medzik.dev> - 2024.1.3-1
-- Update to 2024.1.3 (241.17890.1)
-
-* Thu May 23 2024 M3DZIK <me@medzik.dev> - 2024.1.2-1
-- Update to 2024.1.2 (241.17011.79)
-
-* Tue Apr 30 2024 M3DZIK <me@medzik.dev> - 2024.1.1-1
-- Update to 2024.1.1 (241.15989.150)
-
-* Thu Apr 04 2024 M3DZIK <me@medzik.dev> - 2024.1-1
-- Update to 2024.1 (241.14494.240)
-
-* Thu Mar 21 2024 M3DZIK <me@medzik.dev> - 2023.3.6-1
-- Update to 2023.3.6 (233.15026.9)
-
-* Wed Mar 13 2024 M3DZIK <me@medzik.dev> - 2023.3.5-1
-- Update to 2023.3.5 (233.14808.21)
-
-* Wed Feb 14 2024 M3DZIK <me@medzik.dev> - 2023.3.4-1
-- Update to 2023.3.4 (233.14475.28)
-
-* Fri Jan 26 2024 M3DZIK <me@medzik.dev> - 2023.3.3-1
-- Update to 2023.3.3 (233.14015.106)
-
-* Thu Dec 21 2023 M3DZIK <me@medzik.dev> - 2023.3.2-1
-- Update to 2023.3.2 (233.13135.103)
-
-* Wed Dec 13 2023 M3DZIK <me@medzik.dev> - 2023.3.1-1
-- Update to 2023.3.1 (233.11799.300)
-
-* Thu Dec 07 2023 M3DZIK <me@medzik.dev> - 2023.3-1
-- Update to 2023.3 (233.11799.241)
-
-* Fri Nov 10 2023 M3DZIK <me@medzik.dev> - 2023.2.5-1
-- Update to 2023.2.5 (232.10227.8)
-
-* Thu Oct 26 2023 M3DZIK <me@medzik.dev> - 2023.2.4
-- Update to 2023.2.4 (232.10203.10)
-
-* Thu Oct 12 2023 M3DZIK <me@medzik.dev> - 2023.2.3
-- Update to 2023.2.3 (232.10072.27)
-
-* Thu Sep 14 2023 M3DZIK <me@medzik.dev> - 2023.2.2
-- Update to 2023.2.2 (232.9921.47)
+- Migrated from `intellij-idea-community`
 
 * Thu Aug 31 2023 M3DZIK <me@medzik.dev> - 2023.2.1
 - Initial release

--- a/intellij-idea-community-bin/intellij-idea-community-bin.spec
+++ b/intellij-idea-community-bin/intellij-idea-community-bin.spec
@@ -137,8 +137,5 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{_name}.desktop
 %{_javadir}/%{_name}/jbr
 
 %changelog
-* Fri Jun 21 2024 M3DZIK <me@medzik.dev> - 2024.1.4-1
+* Fri Jun 26 2024 M3DZIK <me@medzik.dev> - 2024.1.4-1
 - Migrated from `intellij-idea-community`
-
-* Thu Aug 31 2023 M3DZIK <me@medzik.dev> - 2023.2.1
-- Initial release

--- a/intellij-idea-community-bin/intellij-idea-community.desktop
+++ b/intellij-idea-community-bin/intellij-idea-community.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=IntelliJ IDEA Community
+GenericName=Capable and Ergonomic Java IDE
+Exec=intellij-idea-community
+Terminal=false
+Icon=intellij-idea-community
+Type=Application
+Categories=Development;IDE;
+StartupWMClass=jetbrains-idea-ce

--- a/intellij-idea-community-bin/updater.conf
+++ b/intellij-idea-community-bin/updater.conf
@@ -1,0 +1,3 @@
+COPR=jetbrains
+TYPE=jetbrains
+JETBRAINS_CODE=IIC

--- a/intellij-idea-community/intellij-idea-community.spec
+++ b/intellij-idea-community/intellij-idea-community.spec
@@ -23,7 +23,7 @@
 
 Name:    intellij-idea-community
 Version: 2024.1.4
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Capable and Ergonomic Java IDE - Community Edition
 License: Apache-2.0
 URL:     https://www.jetbrains.com/%{appname}/
@@ -160,6 +160,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_javadir}/%{name}/jbr
 
 %changelog
+* Fri Jun 26 2024 M3DZIK <me@medzik.dev> - 2024.1.4-3
+- Bump from sources
+
 * Fri Jun 21 2024 M3DZIK <me@medzik.dev> - 2024.1.4-1
 - Update to 2024.1.4 (241.18034.62)
 

--- a/pycharm-community-bin/pycharm-community-bin.spec
+++ b/pycharm-community-bin/pycharm-community-bin.spec
@@ -1,7 +1,7 @@
 # setting some global constants
 %global appname pycharm
-%global build_ver 241.18034.82
-%global idea_name pycharmPC
+
+%global _name pycharm-community
 
 # disable debuginfo subpackage
 %global debug_package %{nil}
@@ -17,37 +17,39 @@
 # there are some python 2 and python 3 scripts so there is no way out to bytecompile them ^_^
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 # do not automatically detect and export provides and dependencies on bundled libraries and executables
-%global _exclude_from %{_javadir}/%{name}/bin/.*|%{_javadir}/%{name}/lib/.*|%{_javadir}/%{name}/plugins/.*|%{_javadir}/%{name}/jbr/.*
+%global _exclude_from %{_javadir}/%{_name}/bin/.*|%{_javadir}/%{_name}/lib/.*|%{_javadir}/%{_name}/plugins/.*|%{_javadir}/%{_name}/jbr/.*
 %global __provides_exclude_from %{_exclude_from}
 %global __requires_exclude_from %{_exclude_from}
 
-Name:    pycharm-community
+Name:    %{_name}-bin
 Version: 2024.1.4
 Release: 2%{?dist}
 Summary: Intelligent Python IDE - Community
 License: Apache-2.0
 URL:     https://www.jetbrains.com/%{appname}/
 
-Source0: %{name}.desktop
+Provides: pycharm-community
+
+Source0: %{_name}.desktop
 
 BuildRequires: desktop-file-utils
 BuildRequires: python3-devel
 BuildRequires: javapackages-filesystem
 BuildRequires: wget
 BuildRequires: tar
-BuildRequires: git
-BuildRequires: p7zip
 
 Requires:      hicolor-icon-theme
 Requires:      javapackages-filesystem
-Recommends:    %{name}-jbr
+Recommends:    %{_name}-jbr
 
 %description
 PyCharm is designed by programmers, for programmers, to provide all the tools you need for productive Python development.
 
 %package jbr
 Summary:  JetBrains Runtime
-Requires: %{name}
+Requires: %{_name}
+
+Provides: %{_name}-jbr
 
 %global __provides_exclude_from %{_exclude_from}
 %global __requires_exclude_from %{_exclude_from}
@@ -56,41 +58,16 @@ Requires: %{name}
 JetBrains Runtime - a patched Java Runtime Environment (JRE).
 
 %prep
-git clone https://github.com/JetBrains/intellij-community -b pycharm/%{build_ver} --depth 1
-cd intellij-community
-git clone git://git.jetbrains.org/idea/android.git android -b pycharm/%{build_ver} --depth 1
-
-%build
-# Building
-cd intellij-community
-./python/installers.cmd -Dintellij.build.target.os=linux
-cd ..
-
-artifact_version=$(echo "%{build_ver}" | sed -E 's|pycharm/||; s|.[0-9]+$||')
-
-idea_target_dir="./intellij-community/out/pycharm-ce/artifacts"
 %ifarch x86_64
-target_file_name="%{idea_name}-${artifact_version}.*.tar.gz"
+download_file="%{_name}-%{version}.tar.gz"
 %else
-target_file_name="%{idea_name}-${artifact_version}.*-aarch64.tar.gz"
+download_file="%{_name}-%{version}-aarch64.tar.gz"
 %endif
 
-target_file_pattern="${idea_target_dir}/${target_file_name}"
-
-%ifarch x86_64
-# Exclude aarch64 from search
-target_file=$(ls ${target_file_pattern} 2>/dev/null | grep -v 'aarch64' | head -n 1)
-%else
-target_file=$(ls ${target_file_pattern} 2>/dev/null | head -n 1)
-%endif
-
-mkdir -p "unpacked"
-tar xf "${target_file}" -C "unpacked"
-mkdir -p "target"
-
-mv "unpacked"/*/* target
-
-cd target
+wget -q "https://download-cf.jetbrains.com/python/$download_file"
+mkdir "${download_file}.out"
+tar xf "$download_file" -C "${download_file}.out"
+mv "${download_file}.out"/*/* .
 
 # Patching shebangs...
 %if 0%{?fedora}
@@ -124,39 +101,37 @@ size_diff=$(( size_before - size_after ))
 echo "Space freed: $size_diff bytes"
 
 %install
-cd target
-
 # Installing application...
-install -d %{buildroot}%{_javadir}/%{name}
-cp -arf ./{bin,jbr,lib,plugins,build.txt,product-info.json} %{buildroot}%{_javadir}/%{name}/
+install -d %{buildroot}%{_javadir}/%{_name}
+cp -arf ./{bin,jbr,lib,plugins,build.txt,product-info.json} %{buildroot}%{_javadir}/%{_name}/
 
 # Installing icons...
 install -d %{buildroot}%{_datadir}/pixmaps
-install -m 0644 -p bin/%{appname}.png %{buildroot}%{_datadir}/pixmaps/%{name}.png
+install -m 0644 -p bin/%{appname}.png %{buildroot}%{_datadir}/pixmaps/%{_name}.png
 install -d %{buildroot}%{_datadir}/icons/hicolor/scalable/apps
-install -m 0644 -p bin/%{appname}.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/%{name}.svg
+install -m 0644 -p bin/%{appname}.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/%{_name}.svg
 
 # Installing launcher...
 install -d %{buildroot}%{_bindir}
-ln -s %{_javadir}/%{name}/bin/%{appname}.sh %{buildroot}%{_bindir}/%{name}
+ln -s %{_javadir}/%{_name}/bin/%{appname}.sh %{buildroot}%{_bindir}/%{_name}
 
 # Installing desktop file...
 install -d %{buildroot}%{_datadir}/applications
-install -m 0644 -p %{SOURCE0} %{buildroot}%{_datadir}/applications/%{name}.desktop
+install -m 0644 -p %{SOURCE0} %{buildroot}%{_datadir}/applications/%{_name}.desktop
 
 %check
-desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
+desktop-file-validate %{buildroot}%{_datadir}/applications/%{_name}.desktop
 
 %files
-%license target/license/*
-%{_javadir}/%{name}/{bin,lib,plugins,build.txt,product-info.json}
-%{_bindir}/%{name}
-%{_datadir}/applications/%{name}.desktop
-%{_datadir}/pixmaps/%{name}.png
-%{_datadir}/icons/hicolor/scalable/apps/%{name}.svg
+%license license/*
+%{_javadir}/%{_name}/{bin,lib,plugins,build.txt,product-info.json}
+%{_bindir}/%{_name}
+%{_datadir}/applications/%{_name}.desktop
+%{_datadir}/pixmaps/%{_name}.png
+%{_datadir}/icons/hicolor/scalable/apps/%{_name}.svg
 
 %files jbr
-%{_javadir}/%{name}/jbr
+%{_javadir}/%{_name}/jbr
 
 %changelog
 * Tue Jun 25 2024 M3DZIK <me@medzik.dev> - 2024.1.4-1

--- a/pycharm-community-bin/pycharm-community-bin.spec
+++ b/pycharm-community-bin/pycharm-community-bin.spec
@@ -23,7 +23,7 @@
 
 Name:    %{_name}-bin
 Version: 2024.1.4
-Release: 2%{?dist}
+Release: 1%{?dist}
 Summary: Intelligent Python IDE - Community
 License: Apache-2.0
 URL:     https://www.jetbrains.com/%{appname}/
@@ -134,50 +134,5 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{_name}.desktop
 %{_javadir}/%{_name}/jbr
 
 %changelog
-* Tue Jun 25 2024 M3DZIK <me@medzik.dev> - 2024.1.4-1
-- Update to 2024.1.4
-
-* Mon Jun 10 2024 M3DZIK <me@medzik.dev> - 2024.1.3-1
-- Update to 2024.1.3
-
-* Wed May 29 2024 M3DZIK <me@medzik.dev> - 2024.1.2-1
-- Update to 2024.1.2
-
-* Tue Apr 30 2024 M3DZIK <me@medzik.dev> - 2024.1.1-1
-- Update to 2024.1.1
-
-* Thu Apr 04 2024 M3DZIK <me@medzik.dev> - 2024.1-1
-- Update to 2024.1
-
-* Fri Mar 22 2024 M3DZIK <me@medzik.dev> - 2023.3.5-1
-- Update to 2023.3.5
-
-* Tue Feb 27 2024 M3DZIK <me@medzik.dev> - 2023.3.4-1
-- Update to 2023.3.4
-
-* Tue Feb 20 2024 M3DZIK <me@medzik.dev> - 2023.3.3-1
-- Update to 2023.3.3
-
-* Fri Dec 22 2023 M3DZIK <me@medzik.dev> - 2023.3.2-1
-- Update to 2023.3.2
-
-* Wed Dec 13 2023 M3DZIK <me@medzik.dev> - 2023.3.1-1
-- Update to 2023.3.1
-
-* Thu Dec 07 2023 M3DZIK <me@medzik.dev> - 2023.3-1
-- Update to 2023.3
-
-* Wed Nov 15 2023 M3DZIK <me@medzik.dev> - 2023.2.5-1
-- Update to 2023.2.5
-
-* Tue Nov 07 2023 M3DZIK <me@medzik.dev> - 2023.2.4
-- Update to 2023.2.4
-
-* Sun Oct 15 2023 M3DZIK <me@medzik.dev> - 2023.2.3
-- Update to 2023.2.3
-
-* Wed Oct 04 2023 M3DZIK <me@medzik.dev> - 2023.2.2
-- Update to 2023.2.2
-
-* Sat Sep 02 2023 M3DZIK <me@medzik.dev> - 2023.2.1
-- Initial release
+* Fri Jun 26 2024 M3DZIK <me@medzik.dev> - 2024.1.4-1
+- Migrated from `pycharm-community`

--- a/pycharm-community-bin/pycharm-community.desktop
+++ b/pycharm-community-bin/pycharm-community.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=PyCharm Community
+GenericName=The intelligent Python IDE
+Exec=pycharm-community
+Terminal=false
+Icon=pycharm-community
+Type=Application
+Categories=Development;IDE;
+StartupWMClass=jetbrains-pycharm-ce

--- a/pycharm-community-bin/updater.conf
+++ b/pycharm-community-bin/updater.conf
@@ -1,0 +1,3 @@
+COPR=jetbrains
+TYPE=jetbrains
+JETBRAINS_CODE=PCC

--- a/pycharm-community/pycharm-community.spec
+++ b/pycharm-community/pycharm-community.spec
@@ -23,7 +23,7 @@
 
 Name:    pycharm-community
 Version: 2024.1.4
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Intelligent Python IDE - Community
 License: Apache-2.0
 URL:     https://www.jetbrains.com/%{appname}/
@@ -159,6 +159,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_javadir}/%{name}/jbr
 
 %changelog
+* Fri Jun 26 2024 M3DZIK <me@medzik.dev> - 2024.1.4-3
+- Build from sources
+
 * Tue Jun 25 2024 M3DZIK <me@medzik.dev> - 2024.1.4-1
 - Update to 2024.1.4
 


### PR DESCRIPTION
IntelliJ IDEA Community and PyCharm Community are now building from sources instead of repacking official JetBrains binaries. Packages from official JetBrains binaries are still available with the `-bin` suffix.